### PR TITLE
[AC-4644] fix(App): Fix No-Index crash of init() | JE

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,11 +106,18 @@ module.exports = (acapi) => {
         // create an elasticsearch client for your Amazon ES
         await getClient({ instance, server, index, debug: _.get(index, 'debug') })
       }
-      const docCount = await getIndexStats({ index })
-      acapi.aclog.listing({
-        field: 'DocCount',
-        value: docCount
-      })
+      try {
+        const docCount = await getIndexStats({ index })
+        acapi.aclog.listing({
+          field: 'DocCount',
+          value: docCount
+        })
+      } catch (err) {
+        acapi.aclog.listing({
+          field: 'DocCount',
+          value: 0
+        })
+      }
     }
   }
 


### PR DESCRIPTION
init() would crash if some indices would not exist yet. This happens in testing. Related issues:
- https://admiralcloud.atlassian.net/browse/AC-4644